### PR TITLE
Fix API key names and section score formatting

### DIFF
--- a/config.py
+++ b/config.py
@@ -146,8 +146,8 @@ def get_secret_or_env(secret_name: str, env_var_name: str) -> Optional[str]:
     return None
 
 api_key_1 = get_secret_or_env("openrouter_api_key_1", "OPENROUTER_API_KEY_1")
-api_key_2 = get_secret_or_env("openrouter_api_key_1", "OPENROUTER_API_KEY_2")
-api_key_3 = get_secret_or_env("openrouter_api_key_1", "OPENROUTER_API_KEY_3")
+api_key_2 = get_secret_or_env("openrouter_api_key_2", "OPENROUTER_API_KEY_2")
+api_key_3 = get_secret_or_env("openrouter_api_key_3", "OPENROUTER_API_KEY_3")
 # --- End API Key Reading --- #
 
 # Filter out any keys that were not found (returned None)

--- a/views.py
+++ b/views.py
@@ -965,7 +965,9 @@ def render_report():
             section_data.append({
                 "Section": section,
                 "Score (%)": f"{score * 100:.1f}%",
-                "Weight": f"{next((s['weight'] * 100 for s in get_questionnaire(*get_regulation_and_industry_for_loader())["sections"] if s['name'] == section), 0):.1f}%",
+                "Weight": (
+                    f"{next((s['weight'] * 100 for s in get_questionnaire(*get_regulation_and_industry_for_loader())['sections'] if s['name'] == section), 0):.1f}%"
+                ),
                 "Status": status
             })
         else:


### PR DESCRIPTION
## Summary
- correct secret names for OpenRouter API keys
- fix f-string weight calculation in `views.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q || true`

------
https://chatgpt.com/codex/tasks/task_e_685cf4c96ffc8326956afed037551eb8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected retrieval of secondary and tertiary OpenRouter API keys to ensure each key is fetched from the appropriate source.

* **Style**
  * Improved readability of the "Weight" field formatting in report sections without altering the output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->