### PR TITLE
Improve grid wrapping for Magic Quadrant

### DIFF
--- a/styles.py
+++ b/styles.py
@@ -917,7 +917,7 @@ def get_magic_quadrant_css():
             justify-content: space-between;
             gap: 20px;
             padding: 10px;
-            flex-wrap: nowrap;
+            flex-wrap: wrap;
         }
         .quadrant-item {
             flex: 1;

--- a/views.py
+++ b/views.py
@@ -1456,7 +1456,7 @@ def render_report():
             justify-content: space-between;
             gap: 20px;
                         padding: 10px;
-            flex-wrap: nowrap;
+            flex-wrap: wrap;
         }
         .quadrant-item {
             flex: 1;
@@ -3115,7 +3115,7 @@ def render_privacy_policy_analyzer() -> None:
                 justify-content: space-between;
                 gap: 20px;
                 padding: 10px;
-                flex-wrap: nowrap;
+                flex-wrap: wrap;
             }
             .quadrant-item {
                 flex: 1;


### PR DESCRIPTION
## Summary
- wrap rows in Magic Quadrant grid on small screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cfa91a73883269501d30319b032bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout of the Magic Quadrant grid, allowing items to wrap onto multiple lines for better display on various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->