### PR TITLE
Fix privacy policy analyzer button width

### DIFF
--- a/views.py
+++ b/views.py
@@ -2896,7 +2896,7 @@ def render_privacy_policy_analyzer() -> None:
                 button_clicked = st.button(
                     "Start Assessment",
                     type="primary",
-                    use_container_width=False,
+                    use_container_width=True,
                     key="ppa_start_assessment_btn"
                 )
                 st.markdown('</div>', unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- adjust width of `Start Assessment` button in privacy policy analyzer so it uses the full container width

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cfa9130ec8326810798a67076ac27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "Start Assessment" button to expand and fill the container width for improved appearance and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->