### PR TITLE
Fix global spacing rule

### DIFF
--- a/views.py
+++ b/views.py
@@ -95,8 +95,10 @@ def render_header():
             padding: 0;
             line-height: 1;
         }
-        /* Remove all Streamlit spacing */
-        .element-container, div[data-testid="stMarkdown"], div[data-testid="stVerticalBlock"] {
+        /* Remove Streamlit spacing only within the header */
+        .app-header .element-container,
+        .app-header div[data-testid="stMarkdown"],
+        .app-header div[data-testid="stVerticalBlock"] {
             margin: 0 !important;
             padding: 0 !important;
         }


### PR DESCRIPTION
## Summary
- scope spacing rules inside `render_header`

## Testing
- `python -m py_compile views.py`


------
https://chatgpt.com/codex/tasks/task_e_685cfa9035108326826ea8cfd8d99c99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved header appearance by refining spacing adjustments to affect only the header area, ensuring consistent layout elsewhere in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->